### PR TITLE
Fix uniqueness error detection in create script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [2.1.1] - 14-08-2026
+
+### Fixed
+
+- Updated uniqueness error detection in create to match on SCIM `scimType` instead of specific error message text
+
 ## [2.1.0] - 09-06-2026
 
 ### Added

--- a/create.ps1
+++ b/create.ps1
@@ -360,7 +360,7 @@ try {
                 $errorObj = Resolve-YsisError -ErrorObject $ex
                 Write-Information "$Iterator : $($_.Exception.Response.StatusCode) - $($errorObj.FriendlyMessage)"
 
-                if ($_.Exception.Response.StatusCode -eq 'Conflict' -and $($errorObj.FriendlyMessage) -match "A user with the 'ysisInitials'") {
+                if ($_.Exception.Response.StatusCode -eq 'Conflict' -and $($errorObj.FriendlyMessage) -match "type: uniqueness") {
                     $Iterator++
                     Write-Warning "Ysis-Initials in use, trying with [$($ysisAccount.'urn:ietf:params:scim:schemas:extension:ysis:2.0:User'.ysisInitials)]"
                 }


### PR DESCRIPTION
## Changes

Updated the uniqueness error detection in `create.ps1` to match on the SCIM `scimType` (`type: uniqueness`) instead of the specific error message text (`A user with the 'ysisInitials'`).

Ysis has changed their error message format, making the previous string match fail. Matching on `scimType` is more future-proof against further message text changes.

## Changelog

- Updated to v2.1.1